### PR TITLE
Add github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+# This workflow will build a Java project with Gradle
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: Android CI with Gradle
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  unit_tests:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Print Java version
+        run: java -version
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Build project
+        run: ./gradlew opensrp-app:build --stacktrace
+      - name: Build APK (Maintain stability)
+        run: ./gradlew opensrp-app:assembleDebug --stacktrace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
           java-version: 1.8
       - name: Print Java version
         run: java -version
+      - name: Uninstall NDK
+        run: sdkmanager --uninstall 'ndk-bundle'
       - name: Add Tasking for build
         run: cd .. && git clone https://github.com/OpenSRP/opensrp-client-tasking.git && cd opensrp-client-tasking && git checkout integrate-goldsmith && cd ../opensrp-client-goldsmith
       - name: Grant execute permission for gradlew

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ name: Android CI with Gradle
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, develop ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, develop ]
 
 jobs:
   unit_tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
           java-version: 1.8
       - name: Print Java version
         run: java -version
+      - name: Add Tasking for build
+        run: cd .. && git clone https://github.com/OpenSRP/opensrp-client-tasking.git && cd opensrp-client-tasking && git checkout integrate-goldsmith && cd ../opensrp-client-goldsmith
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Print Java version
         run: java -version
       - name: Uninstall NDK
-        run: sdkmanager --uninstall 'ndk-bundle'
+        run: sudo /usr/local/lib/android/sdk/tools/bin/sdkmanager --uninstall 'ndk-bundle'
       - name: Add Tasking for build
         run: cd .. && git clone https://github.com/OpenSRP/opensrp-client-tasking.git && cd opensrp-client-tasking && git checkout integrate-goldsmith && cd ../opensrp-client-goldsmith
       - name: Grant execute permission for gradlew

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,6 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build project
-        run: ./gradlew opensrp-app:build --stacktrace
+        run: ./gradlew opensrp-goldsmith:build --stacktrace
       - name: Build APK (Maintain stability)
-        run: ./gradlew opensrp-app:assembleDebug --stacktrace
+        run: ./gradlew opensrp-goldsmith:assembleDebug --stacktrace

--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,7 @@ subprojects {
         maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
         maven { url "https://s3.amazonaws.com/repo.commonsware.com" }
         maven { url "http://dl.bintray.com/ona/kujaku" }
+        maven { url 'https://dl.bintray.com/ibm-watson-health/ibm-fhir-server-releases'}
     }
 
     // Improve build server performance by allowing disabling of pre-dexing

--- a/opensrp-goldsmith/build.gradle
+++ b/opensrp-goldsmith/build.gradle
@@ -173,6 +173,7 @@ dependencies {
         //implementation ('org.smartregister:opensrp-client-tasking:0.0.3.2-SNAPSHOT') {
         exclude group: 'org.smartregister', module: 'opensrp-plan-evaluator'
         exclude group: 'org.smartregister', module: 'opensrp-client-core'
+        exclude group: 'io.ona.rdt-capture'
     }
 
     implementation('org.smartregister:opensrp-client-chw-core:1.6.0.2-GS-PREVIEW-SNAPSHOT') {
@@ -222,7 +223,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-inline:2.13.0'
     testImplementation 'org.robolectric:robolectric:4.3.1'
     testImplementation 'org.robolectric:shadows-multidex:4.3.1'
-    testImplementation 'org.robolectric:shadows-support-v4:3.4-rc2'
+    //testImplementation 'org.robolectric:shadows-support-v4:3.4-rc2'
     testImplementation 'androidx.test:core:1.0.0'
 
     // PowerMock


### PR DESCRIPTION
- This adds a build & assemble debug task to the develop branch to maintain code stability. Build does not always catch compile errors or APK build errors
- Removes the RDT lib so as to reduce the APK size from ~118 MB to ~86MB