### PR TITLE
Layout and related fixes

### DIFF
--- a/opensrp-goldsmith/build.gradle
+++ b/opensrp-goldsmith/build.gradle
@@ -163,7 +163,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.0.9'
 
-    api ('org.smartregister:opensrp-client-core:3.1.0.4-GS-PREVIEW-SNAPSHOT'){
+    api ('org.smartregister:opensrp-client-core:3.1.0.5-GS-PREVIEW-SNAPSHOT'){
         transitive = true
         exclude group: 'com.ibm.fhir', module: 'fhir-model'
         exclude group: 'org.smartregister', module: 'opensrp-plan-evaluator'

--- a/opensrp-goldsmith/src/main/java/org/smartregister/goldsmith/configuration/ToolbarOptions.java
+++ b/opensrp-goldsmith/src/main/java/org/smartregister/goldsmith/configuration/ToolbarOptions.java
@@ -14,6 +14,11 @@ public class ToolbarOptions implements org.smartregister.configuration.ToolbarOp
     }
 
     @Override
+    public int getFabTextStringResource() {
+        return R.string.all_families_add_new_family;
+    }
+
+    @Override
     public boolean isFabEnabled() {
         return true;
     }

--- a/opensrp-goldsmith/src/main/java/org/smartregister/goldsmith/model/RegisterSelectDialogOptionModel.java
+++ b/opensrp-goldsmith/src/main/java/org/smartregister/goldsmith/model/RegisterSelectDialogOptionModel.java
@@ -41,14 +41,14 @@ public class RegisterSelectDialogOptionModel implements DialogOptionModel {
                 // Do nothing
                 break;
         }
-    }   
+    }
 
     private void loadRegister(String moduleName) {
         Context context = ChwApplication.getInstance().getApplicationContext();
         CoreLibrary.getInstance().setCurrentModule(moduleName);
         Intent intent = new Intent(context, BaseConfigurableRegisterActivity.class);
         intent.putExtra(AllConstants.IntentExtra.MODULE_NAME, moduleName);
-        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_NO_HISTORY);
         context.startActivity(intent);
     }
 }

--- a/opensrp-goldsmith/src/main/res/values/strings.xml
+++ b/opensrp-goldsmith/src/main/res/values/strings.xml
@@ -11,6 +11,10 @@
 
     <string name="hello_blank_fragment">Blank fragment</string>
 
+    <!-- ActionBar -->
+    <string name="all_families_add_new_family">Add new family</string>
+    <!-- End of ActionBar -->
+
     <!-- CHW PNC Strings -->
     <string name="date">Date</string>
     <string name="action_taken">Action taken</string>


### PR DESCRIPTION
The following fixes are introduced:
- Setting the "Add register client" FAB text so that the text can be relevant to the register e.g. "Add new family"
- Making the ActionBar icon + text clickable 
- Starting the Configurable Register Activity with `FLAG_ACTIVITY_NO_HISTORY` so that after switching registers we don't have a stack of the Register views