### PR TITLE
Fix progress % values shown for an indicator

### DIFF
--- a/opensrp-goldsmith/src/main/java/org/smartregister/goldsmith/reporting/GoldsmithReportUtils.java
+++ b/opensrp-goldsmith/src/main/java/org/smartregister/goldsmith/reporting/GoldsmithReportUtils.java
@@ -75,8 +75,10 @@ public class GoldsmithReportUtils {
     }
 
     public static String getProgressIndicatorTitle(int count, int percentage) {
-        String signedValue = percentage < 0 ? String.valueOf(percentage - 100) : "+" + percentage;
-        return MessageFormat.format("{0} ({1}%)", count, signedValue);
+        int progressDifference = percentage - 100;
+        String signedValue = percentage < 100 ? String.valueOf(progressDifference) : "+" + progressDifference;
+        String format = count > 0 ? "{0} ({1}%)" : "{0}";
+        return MessageFormat.format(format, count, signedValue);
     }
 
     public static int getBarColor(int percentage) {

--- a/opensrp-goldsmith/src/main/java/org/smartregister/goldsmith/reporting/GoldsmithReportUtils.java
+++ b/opensrp-goldsmith/src/main/java/org/smartregister/goldsmith/reporting/GoldsmithReportUtils.java
@@ -76,7 +76,7 @@ public class GoldsmithReportUtils {
 
     public static String getProgressIndicatorTitle(int count, int percentage) {
         int progressDifference = percentage - 100;
-        String signedValue = percentage < 100 ? String.valueOf(progressDifference) : "+" + progressDifference;
+        String signedValue = percentage <= 100 ? String.valueOf(progressDifference) : "+" + progressDifference;
         String format = count > 0 ? "{0} ({1}%)" : "{0}";
         return MessageFormat.format(format, count, signedValue);
     }


### PR DESCRIPTION
Fix the progress bar title to show the percentage progress deficit or surplus. 
Fixes/See https://github.com/OpenSRP/opensrp-client-goldsmith/issues/73 